### PR TITLE
[SDESK-5839] fix(elastic): Show more than 10 entries in reports

### DIFF
--- a/server/analytics/common.py
+++ b/server/analytics/common.py
@@ -22,6 +22,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+MAX_TERMS_SIZE = 2_147_483_647
+
 
 mime_types = [
     'image/png',

--- a/server/analytics/common.py
+++ b/server/analytics/common.py
@@ -22,7 +22,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-MAX_TERMS_SIZE = 2_147_483_647
+MAX_TERMS_SIZE = 1000
 
 
 mime_types = [

--- a/server/analytics/content_publishing_report/content_publishing_report.py
+++ b/server/analytics/content_publishing_report/content_publishing_report.py
@@ -10,6 +10,7 @@
 
 from analytics.base_report import BaseReportService, BaseReportResource
 from analytics.chart_config import ChartConfig
+from analytics.common import MAX_TERMS_SIZE
 
 
 class ContentPublishingReportResource(BaseReportResource):
@@ -28,6 +29,7 @@ class ContentPublishingReportService(BaseReportService):
         'source': {
             'terms': {
                 'field': 'source',
+                'size': MAX_TERMS_SIZE,
             }
         }
     }
@@ -39,11 +41,9 @@ class ContentPublishingReportService(BaseReportService):
         query = {
             'terms': {
                 'field': agg.get('field'),
+                'size': agg.get('size') or MAX_TERMS_SIZE
             }
         }
-
-        if agg.get('size'):
-            query['terms']['size'] = agg['size']
 
         if include != 'all':
             query['terms']['include'] = include

--- a/server/analytics/desk_activity_report/desk_activity_report.py
+++ b/server/analytics/desk_activity_report/desk_activity_report.py
@@ -14,7 +14,7 @@ from superdesk.errors import SuperdeskApiError
 from analytics.base_report import BaseReportService
 from analytics.stats.common import ENTER_DESK_OPERATIONS, EXIT_DESK_OPERATIONS
 from analytics.chart_config import SDChart, ChartConfig
-from analytics.common import get_utc_offset_in_minutes, REPORT_CONFIG, CHART_TYPES
+from analytics.common import get_utc_offset_in_minutes, REPORT_CONFIG, CHART_TYPES, MAX_TERMS_SIZE
 
 from flask import current_app as app
 from datetime import datetime
@@ -57,6 +57,7 @@ class DeskActivityReportService(BaseReportService):
         'operations': {
             'terms': {
                 'field': 'stats.timeline.operation',
+                'size': MAX_TERMS_SIZE,
             }
         }
     }

--- a/server/analytics/planning_usage_report/planning_usage_report.py
+++ b/server/analytics/planning_usage_report/planning_usage_report.py
@@ -13,6 +13,7 @@ from superdesk.resource import Resource
 
 from analytics.chart_config import ChartConfig
 from analytics.base_report import BaseReportService
+from analytics.common import MAX_TERMS_SIZE
 
 
 class PlanningUsageReportResource(Resource):
@@ -57,6 +58,7 @@ class PlanningUsageReportService(BaseReportService):
                 'users': {
                     'terms': {
                         'field': 'original_creator',
+                        'size': MAX_TERMS_SIZE,
                     }
                 }
             }
@@ -67,6 +69,7 @@ class PlanningUsageReportService(BaseReportService):
                 'users': {
                     'terms': {
                         'field': 'original_creator',
+                        'size': MAX_TERMS_SIZE,
                     }
                 }
             }
@@ -77,6 +80,7 @@ class PlanningUsageReportService(BaseReportService):
                 'users': {
                     'terms': {
                         'field': 'original_creator',
+                        'size': MAX_TERMS_SIZE
                     }
                 }
             }
@@ -87,6 +91,7 @@ class PlanningUsageReportService(BaseReportService):
                 'users': {
                     'terms': {
                         'field': 'coverages.original_creator',
+                        'size': MAX_TERMS_SIZE
                     }
                 }
             }

--- a/server/analytics/production_time_report/production_time_report.py
+++ b/server/analytics/production_time_report/production_time_report.py
@@ -12,7 +12,7 @@ from superdesk.resource import Resource
 
 from analytics.stats.stats_report_service import StatsReportService
 from analytics.chart_config import SDChart, ChartConfig
-from analytics.common import seconds_to_human_readable
+from analytics.common import seconds_to_human_readable, MAX_TERMS_SIZE
 
 
 class ProductionTimeReportResource(Resource):
@@ -46,6 +46,7 @@ class ProductionTimeReportService(StatsReportService):
         'operations': {
             'terms': {
                 'field': 'stats.timeline.operation',
+                'size': MAX_TERMS_SIZE
             }
         }
     }
@@ -74,6 +75,7 @@ class ProductionTimeReportService(StatsReportService):
                             'desks': {
                                 'terms': {
                                     'field': 'stats.desk_transitions.desk',
+                                    'size': MAX_TERMS_SIZE
                                 },
                                 'aggs': {
                                     'stats': {

--- a/server/analytics/publishing_performance_report/publishing_performance_report.py
+++ b/server/analytics/publishing_performance_report/publishing_performance_report.py
@@ -8,9 +8,10 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from superdesk import get_resource_service
 from analytics.base_report import BaseReportService, BaseReportResource
 from analytics.chart_config import ChartConfig
-from superdesk import get_resource_service
+from analytics.common import MAX_TERMS_SIZE
 
 
 class PublishingPerformanceReportResource(BaseReportResource):
@@ -28,6 +29,7 @@ class PublishingPerformanceReportService(BaseReportService):
         'source': {
             'terms': {
                 'field': 'source',
+                'size': MAX_TERMS_SIZE
             }
         }
     }
@@ -39,6 +41,7 @@ class PublishingPerformanceReportService(BaseReportService):
         query = {
             'terms': {
                 'field': agg.get('field'),
+                'size': agg.get('size') or MAX_TERMS_SIZE,
             },
             'aggs': {
                 'no_rewrite_of': {
@@ -54,7 +57,8 @@ class PublishingPerformanceReportService(BaseReportService):
                     'aggs': {
                         'state': {
                             'terms': {
-                                'field': 'state'
+                                'field': 'state',
+                                'size': MAX_TERMS_SIZE,
                             }
                         }
                     }
@@ -68,16 +72,14 @@ class PublishingPerformanceReportService(BaseReportService):
                     'aggs': {
                         'state': {
                             'terms': {
-                                'field': 'state'
+                                'field': 'state',
+                                'size': MAX_TERMS_SIZE,
                             }
                         }
                     }
                 }
             }
         }
-
-        if agg.get('size'):
-            query['terms']['size'] = agg['size']
 
         if include != 'all':
             query['terms']['include'] = include

--- a/server/analytics/tests/fixtures.py
+++ b/server/analytics/tests/fixtures.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2021 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+FIXTURES = {
+    'categories': [
+        {'name': 'Australian General News', 'is_active': True, 'qcode': 'a'},
+        {'name': 'Australian Weather', 'is_active': True, 'subject': '17000000', 'qcode': 'b'},
+        {'name': 'General Features', 'is_active': True, 'qcode': 'c'},
+        {'name': 'Reserved (obsolete/unused)', 'is_active': False, 'qcode': 'd'},
+        {'name': 'Entertainment', 'is_active': True, 'subject': '01000000', 'qcode': 'e'},
+        {'name': 'Finance', 'is_active': True, 'subject': '04000000', 'qcode': 'f'},
+        {'name': 'SportSet', 'is_active': False, 'qcode': 'g'},
+        {'name': 'FormGuide', 'is_active': True, 'qcode': 'h'},
+        {'name': 'International News', 'is_active': True, 'qcode': 'i'},
+        {'name': 'Supplementary Traffic', 'is_active': True, 'qcode': 'k'},
+        {'name': 'Press Release Service', 'is_active': True, 'qcode': 'j'},
+        {'name': 'Lotteries', 'is_active': True, 'qcode': 'l'},
+        {'name': 'Line Check Messages', 'is_active': True, 'qcode': 'm'},
+        {'name': 'NZN', 'is_active': True, 'qcode': 'n'},
+        {'name': 'State Parliaments', 'is_active': True, 'subject': '11000000', 'qcode': 'o'},
+        {'name': 'Federal Parliament', 'is_active': True, 'subject': '11000000', 'qcode': 'p'},
+        {'name': 'Stockset', 'is_active': True, 'subject': '04000000', 'qcode': 'q'},
+        {'name': 'Racing (Turf)', 'is_active': True, 'subject': '15030001', 'qcode': 'r'},
+        {'name': 'Overseas Sport', 'is_active': True, 'subject': '15000000', 'qcode': 's'},
+        {'name': 'Domestic Sport', 'is_active': True, 'subject': '15000000', 'qcode': 't'},
+        {'name': 'Medianet Emergency News Wire', 'is_active': True, 'qcode': 'u'},
+        {'name': 'Advisories', 'is_active': True, 'qcode': 'v'},
+        {'name': 'Medianet NZ Wire', 'is_active': True, 'qcode': 'w'},
+        {'name': 'Special Events (olympics/ Aus elections)', 'is_active': True, 'qcode': 'x'},
+        {'name': 'Special Events (obsolete/unused)', 'is_active': False, 'qcode': 'y'},
+        {'name': 'Supplementary Traffic', 'is_active': False, 'qcode': 'z'}
+    ]
+}

--- a/server/analytics/tests/steps.py
+++ b/server/analytics/tests/steps.py
@@ -8,10 +8,12 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk.tests.steps import when, then, assert_200, assert_equal, get_json_data, json,\
+from superdesk import get_resource_service
+from superdesk.tests.steps import given, when, then, assert_200, assert_equal, get_json_data, json,\
     fail_and_print_body, apply_placeholders, json_match
 
 from analytics.stats.gen_archive_statistics import GenArchiveStatistics
+from .fixtures import FIXTURES
 
 
 @then('we get {total_count} charts')
@@ -169,3 +171,14 @@ def step_impl_then_get_stats_for_item(context):
                 stat_index += 1
 
         return response_data
+
+
+@given('the vocab fixture "{resource}"')
+def step_impl_given_the_test_vocabularies(context, resource):
+    with context.app.test_request_context(context.app.config["URL_PREFIX"]):
+        service = get_resource_service('vocabularies')
+        service.delete_action()
+        service.post([{
+            '_id': resource,
+            'items': FIXTURES[resource]
+        }])

--- a/server/features/content_publishing_report.feature
+++ b/server/features/content_publishing_report.feature
@@ -259,3 +259,33 @@ Feature: Content Publishing Report
         }]}
         """
 
+    @auth
+    Scenario: Displays results with more than 10 entries
+        Given the vocab fixture "categories"
+        Given "archived"
+        """
+        [{
+            "_id": "a1-1",
+            "_type": "archived",
+            "anpa_category": [
+                {"qcode": "a"}, {"qcode": "b"}, {"qcode": "c"}, {"qcode": "d"},
+                {"qcode": "e"}, {"qcode": "f"}, {"qcode": "g"}, {"qcode": "h"},
+                {"qcode": "i"}, {"qcode": "j"}, {"qcode": "k"}, {"qcode": "l"},
+                {"qcode": "m"}, {"qcode": "n"}, {"qcode": "o"}, {"qcode": "p"},
+                {"qcode": "q"}, {"qcode": "r"}, {"qcode": "s"}, {"qcode": "t"},
+                {"qcode": "u"}, {"qcode": "v"}, {"qcode": "w"}, {"qcode": "x"},
+                {"qcode": "y"}, {"qcode": "z"}
+            ]
+        }]
+        """
+        When we get "/content_publishing_report?params={"min": 1}&aggs={"group": {"field": "anpa_category.qcode"}}"
+        Then we get list with 1 items
+        """
+        {"_items": [{
+            "groups": {
+                "a": 1, "b": 1, "c": 1, "d": 1, "e": 1, "f": 1, "g": 1, "h": 1, "i": 1,
+                "j": 1, "k": 1, "l": 1, "m": 1, "n": 1, "o": 1, "p": 1, "q": 1, "r": 1,
+                "s": 1, "t": 1, "u": 1, "v": 1, "w": 1, "x": 1, "y": 1, "z": 1
+            }
+        }]}
+        """


### PR DESCRIPTION
This was caused by the deprecation of `'size': 0` in elasticsearch (which set `size` to `Integer.MAX_VALUE`)