### PR TITLE
[SDESK-7590] Upgrade Analytics saved reports to async

### DIFF
--- a/server/analytics/commands/send_schedule_reports_test.py
+++ b/server/analytics/commands/send_schedule_reports_test.py
@@ -141,8 +141,7 @@ class SendScheduleReportTestCase(BaseTestCase):
         )
 
         scheduled_service = get_resource_service("scheduled_reports")
-
-        report = scheduled_service.find_one(req=None, _id="sched1")
+        report = await scheduled_service.find_one_async(req=None, _id="sched1")
         self.assertNotIn("_last_sent", report)
 
         # Simulate running every hour for a few hours
@@ -158,7 +157,7 @@ class SendScheduleReportTestCase(BaseTestCase):
                 SendScheduledReports().run(now_utc)
 
                 # _last sent is updated
-                report = scheduled_service.find_one(req=None, _id="sched1")
+                report = await scheduled_service.find_one_async(req=None, _id="sched1")
                 self.assertEqual(report.get("_last_sent"), now_utc)
 
             # Test that the command sent emails across the 4 iterations
@@ -210,8 +209,7 @@ class SendScheduleReportTestCase(BaseTestCase):
         )
 
         scheduled_service = get_resource_service("scheduled_reports")
-
-        report = scheduled_service.find_one(req=None, _id="sched1")
+        report = await scheduled_service.find_one_async(req=None, _id="sched1")
         self.assertNotIn("_last_sent", report)
 
         # Simulate running every hour for a few hours
@@ -228,7 +226,7 @@ class SendScheduleReportTestCase(BaseTestCase):
                 SendScheduledReports().run(now_utc)
 
                 # _last sent is updated
-                report = scheduled_service.find_one(req=None, _id="sched1")
+                report = await scheduled_service.find_one_async(req=None, _id="sched1")
 
                 if not should_have_updated:
                     should_have_updated = True

--- a/server/analytics/commands/send_scheduled_reports.py
+++ b/server/analytics/commands/send_scheduled_reports.py
@@ -75,6 +75,7 @@ class SendScheduledReports(Command):
                 self._send_report(scheduled_report)
 
                 # Update the _last_sent of the schedule
+                # TODO-ASYNC: update all usages of `scheduled_reports` once the command is migrated to async
                 get_resource_service("scheduled_reports").system_update(
                     scheduled_report.get("_id"),
                     {"_last_sent": now_utc},
@@ -133,6 +134,7 @@ class SendScheduledReports(Command):
     @staticmethod
     def _send_report(scheduled_report):
         email_service = get_resource_service("email_report")
+        # TODO-ASYNC: update usage of `saved_reports` to async once the command is async
         saved_report = get_resource_service("saved_reports").find_one(
             req=None, _id=scheduled_report.get("saved_report")
         )

--- a/server/analytics/reports/scheduled_reports.py
+++ b/server/analytics/reports/scheduled_reports.py
@@ -9,8 +9,8 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 from superdesk import get_resource_service
-from superdesk.services import BaseService
 from superdesk.resource import Resource
+from superdesk.eve_async import AsyncBaseService
 from superdesk.notification import push_notification
 from superdesk.errors import SuperdeskApiError
 
@@ -83,24 +83,24 @@ class ScheduledReportsResource(Resource):
     }
 
 
-class ScheduledReportsService(BaseService):
-    def on_created(self, docs):
+class ScheduledReportsService(AsyncBaseService):
+    async def on_created_async(self, docs: list[dict]):
         for doc in docs:
             self.set_schedule(doc)
-            self._validate_on_create_or_update(doc)
+            await self._validate_on_create_or_update(doc)
             self._push_notification(doc, "create")
 
-    def on_updated(self, updates, original):
+    async def on_updated_async(self, updates: dict, original: dict):
         self.set_schedule(updates)
         doc = deepcopy(original)
         doc.update(updates)
-        self._validate_on_create_or_update(doc)
+        await self._validate_on_create_or_update(doc)
         self._push_notification(original, "update")
 
-    def on_deleted(self, doc):
+    async def on_deleted_async(self, doc: dict):
         self._push_notification(doc, "delete")
 
-    def set_schedule(self, updates):
+    def set_schedule(self, updates: dict):
         # Sometimes 'schedule' is not in the updates provided
         # Eve/Cerberus will ensure the document has 'schedule' set
         # as it is configured as required
@@ -124,9 +124,9 @@ class ScheduledReportsService(BaseService):
             updates["schedule"].update({"frequency": "monthly", "hour": hour, "day": day, "week_days": []})
 
     @staticmethod
-    def _validate_on_create_or_update(doc):
+    async def _validate_on_create_or_update(doc: dict):
         saved_service = get_resource_service("saved_reports")
-        saved_report = saved_service.find_one(req=None, _id=doc["saved_report"])
+        saved_report = await saved_service.find_one_async(req=None, _id=doc["saved_report"])
 
         if not saved_report.get("is_global"):
             raise SuperdeskApiError.badRequestError("A schedule must be attached to a global saved report")

--- a/server/analytics/saved_reports.py
+++ b/server/analytics/saved_reports.py
@@ -63,7 +63,7 @@ class SavedReportsService(AsyncBaseService):
         Checks if the request owner and the saved search owner are the same person
         If not then the request owner should have global saved reports privilege
         """
-        self._validate_on_update(updates, original)
+        await self._validate_on_update(updates, original)
         self._null_updates_from_original(updates, original)
         await super().on_update_async(updates, original)
 
@@ -71,7 +71,7 @@ class SavedReportsService(AsyncBaseService):
         self._push_notification(original, "update")
 
     async def on_delete_async(self, doc: dict):
-        self._validate_on_delete(doc)
+        await self._validate_on_delete(doc)
 
     async def on_deleted_async(self, doc: dict):
         self._push_notification(doc, "delete")
@@ -101,7 +101,7 @@ class SavedReportsService(AsyncBaseService):
         return await super().get_async(req, lookup=None)
 
     @staticmethod
-    def _push_notification(doc, operation):
+    def _push_notification(doc: dict, operation: str):
         push_notification(
             "savedreports:update",
             report_type=doc["report"],
@@ -112,7 +112,7 @@ class SavedReportsService(AsyncBaseService):
         )
 
     @staticmethod
-    def _validate_on_create(doc):
+    def _validate_on_create(doc: dict):
         """
         User can only create global report if they have 'global_saved_reports' permission
         """
@@ -120,7 +120,7 @@ class SavedReportsService(AsyncBaseService):
             raise SuperdeskApiError.forbiddenError("Unauthorized to create global report.")
 
     @staticmethod
-    def _validate_ownership(doc):
+    def _validate_ownership(doc: dict):
         """
         Validate saved reports on update/delete
 
@@ -134,30 +134,31 @@ class SavedReportsService(AsyncBaseService):
             elif not current_user_has_privilege("global_saved_reports"):
                 raise SuperdeskApiError.forbiddenError("Unauthorized to modify global report.")
 
-    def _validate_on_update(self, updates, original):
-        self._validate_ownership(original)
+    async def _validate_on_update(self, updates: dict, original: dict):
+        await self._validate_ownership(original)
 
         scheduled_service = get_resource_service("scheduled_reports")
-        schedules = scheduled_service.get(req=None, lookup={"saved_report": original["_id"]})
+        schedules_count = await scheduled_service.count_async({"saved_report": original["_id"]})
 
-        if schedules.count() > 0:
+        if schedules_count > 0:
             if original.get("is_global") and not updates.get("is_global"):
                 raise SuperdeskApiError.badRequestError("Cannot remove global flag as schedule(s) are attached")
 
-    def _validate_on_delete(self, doc):
+    async def _validate_on_delete(self, doc: dict):
         self._validate_ownership(doc)
 
         scheduled_service = get_resource_service("scheduled_reports")
-        schedules = scheduled_service.get(req=None, lookup={"saved_report": doc["_id"]})
+        schedules_count = await scheduled_service.count_async({"saved_report": doc["_id"]})
 
-        if schedules.count() > 0:
+        if schedules_count > 0:
             raise SuperdeskApiError.badRequestError("Cannot delete saved report as schedule(s) are attached")
 
-    def get_aggregations(self, req, **lookup):
-        saved_report = self.find_one(req=req, **lookup)
+    async def get_aggregations(self, req: ParsedRequest | None, **lookup: dict):
+        saved_report = await self.find_one_async(req=req, **lookup)
         if not saved_report:
             raise SuperdeskApiError.notFoundError("Saved report not found")
 
+        # TODO-ASYNC: update usage of `get_report_service` to async once all reports are async
         report_service = get_report_service(saved_report.get("report"))
         if report_service is None:
             raise SuperdeskApiError.badRequestError("Invalid report type")
@@ -170,7 +171,7 @@ class SavedReportsService(AsyncBaseService):
 
         return saved_report, aggregations
 
-    def _null_updates_from_original(self, updates, original):
+    def _null_updates_from_original(self, updates: dict, original: dict):
         """Null values that are not in the updated report params"""
 
         self._null_values(updates, original, "translations")
@@ -183,7 +184,7 @@ class SavedReportsService(AsyncBaseService):
             self._null_values(updates["params"], original["params"], "aggs")
             self._null_values(updates["params"], original["params"], "repos")
 
-    def _null_values(self, updates, original, field):
+    def _null_values(self, updates: dict, original: dict, field: str):
         """Sets values to None that are in original but not in updates"""
 
         if field not in updates:

--- a/server/analytics/saved_reports.py
+++ b/server/analytics/saved_reports.py
@@ -8,12 +8,12 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from superdesk import json, get_resource_service
-from superdesk.services import BaseService
 from superdesk.resource import Resource
-from superdesk.notification import push_notification
 from superdesk.errors import SuperdeskApiError
+from superdesk import json, get_resource_service
+from superdesk.notification import push_notification
 from superdesk.users.services import current_user_has_privilege
+from superdesk.eve_async import AsyncBaseService
 
 from apps.auth import get_user_id
 from apps.archive.common import get_user, get_auth
@@ -46,18 +46,18 @@ class SavedReportsResource(Resource):
     }
 
 
-class SavedReportsService(BaseService):
-    def on_create(self, docs):
+class SavedReportsService(AsyncBaseService):
+    async def on_create_async(self, docs: list[dict]):
         for doc in docs:
             self._validate_on_create(doc)
             doc["user"] = get_user_id(required=True)
-        super().on_create(docs)
+        await super().on_create_async(docs)
 
-    def on_created(self, docs):
+    async def on_created_async(self, docs: list[dict]):
         for doc in docs:
             self._push_notification(doc, "create")
 
-    def on_update(self, updates, original):
+    async def on_update_async(self, updates: dict, original: dict):
         """Runs on update
 
         Checks if the request owner and the saved search owner are the same person
@@ -65,18 +65,18 @@ class SavedReportsService(BaseService):
         """
         self._validate_on_update(updates, original)
         self._null_updates_from_original(updates, original)
-        super().on_update(updates, original)
+        await super().on_update_async(updates, original)
 
-    def on_updated(self, updates, original):
+    async def on_updated_async(self, updates: dict, original: dict):
         self._push_notification(original, "update")
 
-    def on_delete(self, doc):
+    async def on_delete_async(self, doc: dict):
         self._validate_on_delete(doc)
 
-    def on_deleted(self, doc):
+    async def on_deleted_async(self, doc: dict):
         self._push_notification(doc, "delete")
 
-    def get(self, req, lookup):
+    async def get_async(self, req: ParsedRequest | None, lookup: dict | None):
         """
         Overriding to pass user as search parameter
         """
@@ -98,7 +98,7 @@ class SavedReportsService(BaseService):
 
         req.where = json.dumps(where)
 
-        return super().get(req, lookup=None)
+        return await super().get_async(req, lookup=None)
 
     @staticmethod
     def _push_notification(doc, operation):


### PR DESCRIPTION
### Purpose
To upgrade to async the saved reports (`saved_reports` & `scheduled_reports`) to use new `AsyncBaseService`

### What has changes
- Updated services to use async base one
- Updated references to those services and use async methods

Resolves: [SDESK-7590]

[SDESK-7590]: https://sofab.atlassian.net/browse/SDESK-7590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ