### PR TITLE
[SDESK-7591] Upgrade Analytics statistics to async

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Environment
         run: ./scripts/ci-install.sh
       - name: Pytest
-        run: pytest --log-level=ERROR --disable-warnings
+        run: pytest --log-level=ERROR -vv --disable-warnings
       - name: Behave
         working-directory: ./server
         run: behave --format progress2 --logging-level=ERROR

--- a/server/analytics/__init__.py
+++ b/server/analytics/__init__.py
@@ -28,7 +28,7 @@ from analytics.planning_usage_report import init_app as init_planning_usage_repo
 from analytics.stats import init_app as init_stats
 from analytics.desk_activity_report import init_app as init_desk_activity_report
 from analytics.production_time_report import init_app as init_production_time_report
-from analytics.user_activity_report import init_app as init_user_acitivity_report
+from analytics.user_activity_report import init_app as init_user_activity_report
 from analytics.featuremedia_updates_report import (
     init_app as init_featuremedia_updates_report,
 )
@@ -111,7 +111,7 @@ def init_app(app):
     init_stats(app)
     init_desk_activity_report(app)
     init_production_time_report(app)
-    init_user_acitivity_report(app)
+    init_user_activity_report(app)
     init_featuremedia_updates_report(app)
     init_update_time_report(app)
 

--- a/server/analytics/base_report/__init__.py
+++ b/server/analytics/base_report/__init__.py
@@ -82,7 +82,7 @@ class BaseReportService(SearchService):
         """
         pass
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         """
         Overwrite this method to generate a report based on the aggregation data
         """
@@ -91,7 +91,7 @@ class BaseReportService(SearchService):
 
         return self.get_aggregation_buckets(docs.hits)
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         """
         Overwrite this method to generate the highcharts config based on the aggregation data
         """
@@ -258,13 +258,12 @@ class BaseReportService(SearchService):
     def get_elastic_index(self, types):
         return es_utils.get_index(types)
 
-    def run_query(self, params, args):
+    async def run_query(self, params, args):
         query = params.get("source") or {}
         if "query" not in query:
             query["query"] = {"filtered": {}}
 
-        aggs = self.get_request_aggregations(params, args)
-        if aggs:
+        if aggs := self.get_request_aggregations(params, args):
             query["aggs"] = aggs
 
         types = params.get("repo")
@@ -286,21 +285,18 @@ class BaseReportService(SearchService):
         if filters:
             set_filters(query, filters)
 
-        index = self.get_elastic_index(types)
-
         self.get_custom_aggs_query(query, aggs)
-
-        docs = self.elastic.search(query, types, params={})
+        docs = await self.elastic_async.search(query, types, params={})
 
         app = get_current_app().as_any()
         for resource in types:
-            response = {ITEMS: [doc for doc in docs if doc["_type"] == resource]}
+            response = {ITEMS: [doc async for doc in docs if doc["_type"] == resource]}
             getattr(app, "on_fetched_resource")(resource, response)
             getattr(app, "on_fetched_resource_%s" % resource)(response)
 
         return docs
 
-    def get(self, req, **lookup):
+    async def get_async(self, req, **lookup):
         args = self._get_request_or_lookup(req, **lookup)
 
         if args.get("source"):
@@ -316,16 +312,16 @@ class BaseReportService(SearchService):
         else:
             raise SuperdeskApiError.badRequestError("source/query not provided")
 
-        docs = self.run_query(params, args)
+        docs = await self.run_query(params, args)
 
         if args["return_type"] == "highcharts_config":
-            report = self.generate_highcharts_config(docs, args)
+            report = await self.generate_highcharts_config(docs, args)
         elif args["return_type"] == MIME_TYPES.CSV:
             report = self.generate_csv(docs, args)
         elif args["return_type"] == MIME_TYPES.HTML:
             report = self.generate_html(docs, args)
         else:
-            report = self.generate_report(docs, args)
+            report = await self.generate_report(docs, args)
 
         if "include_items" in args and int(args["include_items"]):
             report["_items"] = list(docs)

--- a/server/analytics/content_publishing_report/content_publishing_report.py
+++ b/server/analytics/content_publishing_report/content_publishing_report.py
@@ -65,7 +65,7 @@ class ContentPublishingReportService(BaseReportService):
 
         return aggregations
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         """Returns the publishing statistics
 
         :param docs: document used for generating the statistics
@@ -119,7 +119,7 @@ class ContentPublishingReportService(BaseReportService):
 
         return report
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         params = args.get("params") or {}
         aggs = args.get("aggs") or {}
         group = aggs.get("group") or {}
@@ -129,7 +129,7 @@ class ContentPublishingReportService(BaseReportService):
         chart = params.get("chart") or {}
         chart_type = chart.get("type") or "bar"
 
-        report = self.generate_report(docs, args)
+        report = await self.generate_report(docs, args)
 
         chart_config = ChartConfig("content_publishing", chart_type)
 

--- a/server/analytics/content_publishing_report/content_publishing_report_test.py
+++ b/server/analytics/content_publishing_report/content_publishing_report_test.py
@@ -8,137 +8,136 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from asyncio import sleep
 from superdesk import get_resource_service
 from superdesk.metadata.item import ITEM_STATE, CONTENT_STATE
-from superdesk.tests import TestCase
-
-from analytics import init_app
+from analytics.tests import BaseTestCase
 
 
-class ContentPublishingReportTestCase(TestCase):
-    def setUp(self):
-        self.maxDiff = None
+class ContentPublishingReportTestCase(BaseTestCase):
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.service = get_resource_service("content_publishing_report")
+        self.app.data.insert(
+            "published",
+            [
+                {
+                    "_id": "item1",
+                    "task": {"desk": "de1", "stage": "st1"},
+                    ITEM_STATE: CONTENT_STATE.PUBLISHED,
+                    "anpa_category": [{"qcode": "advisory", "name": "Advisories"}],
+                    "source": "AAP",
+                },
+                {
+                    "_id": "item2",
+                    "task": {"desk": "de1", "stage": "st1"},
+                    ITEM_STATE: CONTENT_STATE.PUBLISHED,
+                    "anpa_category": [{"qcode": "domestic_sport", "name": "Domestic Sport"}],
+                    "subject": [
+                        {"name": "BTL/ECO", "qcode": "btl", "scheme": "packages"},
+                        {"name": "Canadian", "qcode": "candian", "scheme": "keywords"},
+                    ],
+                    "source": "AAP",
+                },
+                {
+                    "_id": "item3",
+                    "task": {"desk": "de1", "stage": "st1"},
+                    ITEM_STATE: CONTENT_STATE.PUBLISHED,
+                    "anpa_category": [{"qcode": "finance", "name": "Finance"}],
+                    "subject": [{"name": "Aap", "qcode": "aap", "scheme": "keywords"}],
+                    "source": "AAP",
+                },
+                {
+                    "_id": "item4",
+                    "task": {"desk": "de1", "stage": "st1"},
+                    ITEM_STATE: CONTENT_STATE.PUBLISHED,
+                    "subject": [
+                        {"name": "Aap", "qcode": "aap", "scheme": "keywords"},
+                        {"name": "BIN/ALG", "qcode": "bin", "scheme": "packages"},
+                    ],
+                    "source": "AAP",
+                },
+            ],
+        )
 
-        with self.app.app_context():
-            init_app(self.app)
-            self.service = get_resource_service("content_publishing_report")
-            self.app.data.insert(
-                "published",
-                [
-                    {
-                        "_id": "item1",
-                        "task": {"desk": "de1", "stage": "st1"},
-                        ITEM_STATE: CONTENT_STATE.PUBLISHED,
-                        "anpa_category": [{"qcode": "advisory", "name": "Advisories"}],
-                        "source": "AAP",
-                    },
-                    {
-                        "_id": "item2",
-                        "task": {"desk": "de1", "stage": "st1"},
-                        ITEM_STATE: CONTENT_STATE.PUBLISHED,
-                        "anpa_category": [{"qcode": "domestic_sport", "name": "Domestic Sport"}],
-                        "subject": [
-                            {"name": "BTL/ECO", "qcode": "btl", "scheme": "packages"},
-                            {"name": "Canadian", "qcode": "candian", "scheme": "keywords"},
-                        ],
-                        "source": "AAP",
-                    },
-                    {
-                        "_id": "item3",
-                        "task": {"desk": "de1", "stage": "st1"},
-                        ITEM_STATE: CONTENT_STATE.PUBLISHED,
-                        "anpa_category": [{"qcode": "finance", "name": "Finance"}],
-                        "subject": [{"name": "Aap", "qcode": "aap", "scheme": "keywords"}],
-                        "source": "AAP",
-                    },
-                    {
-                        "_id": "item4",
-                        "task": {"desk": "de1", "stage": "st1"},
-                        ITEM_STATE: CONTENT_STATE.PUBLISHED,
-                        "subject": [
-                            {"name": "Aap", "qcode": "aap", "scheme": "keywords"},
-                            {"name": "BIN/ALG", "qcode": "bin", "scheme": "packages"},
-                        ],
-                        "source": "AAP",
-                    },
-                ],
-            )
+    async def test_get_aggregation_buckets(self):
+        # TODO-ASYNC: figure out why there is a race condition. pytest rerun won't work either
+        await sleep(1)
 
-    def test_get_aggregation_buckets(self):
-        with self.app.app_context():
-            params = {
-                "source": {
-                    "query": {
-                        "filtered": {
-                            "filter": {
-                                "bool": {
-                                    "must": [],
-                                    "must_not": [],
-                                }
+        params = {
+            "source": {
+                "query": {
+                    "filtered": {
+                        "filter": {
+                            "bool": {
+                                "must": [],
+                                "must_not": [],
                             }
                         }
-                    },
-                    "size": 0,
-                    "from": 0,
-                    "sort": [{"versioncreated": "desc"}],
+                    }
                 },
-                "page": 1,
-                "max_results": 0,
-                "aggs": {
-                    "group": {"field": "anpa_category.qcode", "size": 0},
-                    "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
-                },
-            }
-            args = {
-                "aggs": {
-                    "group": {"field": "anpa_category.qcode", "size": 0},
-                    "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
-                },
-                "params": {
-                    "dates": {},
-                    "must": {},
-                    "must_not": {},
-                    "min": 1,
-                    "chart": {"type": "column", "sort_order": "desc"},
-                },
-                "return_type": "aggregations",
-            }
-
-            docs = self.service.run_query(params, args)
-            report = self.service.generate_report(docs, args)
-            assert {
-                "groups": {"advisory": {}, "domestic_sport": {"candian": 1}, "finance": {"aap": 1}},
-                "subgroups": {"candian": 1, "aap": 1},
-            } == report
-
-            params["aggs"] = {
-                "group": {"field": '{"scheme":"packages"}', "size": 0},
+                "size": 0,
+                "from": 0,
+                "sort": [{"versioncreated": "desc"}],
+            },
+            "page": 1,
+            "max_results": 0,
+            "aggs": {
+                "group": {"field": "anpa_category.qcode", "size": 0},
                 "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
-            }
-            args["aggs"] = {
-                "group": {"field": '{"scheme":"packages"}', "size": 0},
+            },
+        }
+        args = {
+            "aggs": {
+                "group": {"field": "anpa_category.qcode", "size": 0},
                 "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
-            }
+            },
+            "params": {
+                "dates": {},
+                "must": {},
+                "must_not": {},
+                "min": 1,
+                "chart": {"type": "column", "sort_order": "desc"},
+            },
+            "return_type": "aggregations",
+        }
 
-            docs = self.service.run_query(params, args)
-            report = self.service.generate_report(docs, args)
-            assert {
-                "groups": {"bin": {"aap": 1}, "btl": {"candian": 1}},
-                "subgroups": {"aap": 1, "candian": 1},
-            } == report
+        docs = await self.service.run_query(params, args)
+        report = await self.service.generate_report(docs, args)
 
-            params["aggs"] = {
-                "group": {"field": '{"scheme":"keywords"}', "size": 0},
-                "subgroup": {"field": "anpa_category.qcode", "size": 0},
-            }
-            args["aggs"] = {
-                "group": {"field": '{"scheme":"packages"}', "size": 0},
-                "subgroup": {"field": "anpa_category.qcode", "size": 0},
-            }
+        assert {
+            "groups": {"advisory": {}, "domestic_sport": {"candian": 1}, "finance": {"aap": 1}},
+            "subgroups": {"candian": 1, "aap": 1},
+        } == report
 
-            docs = self.service.run_query(params, args)
-            report = self.service.generate_report(docs, args)
-            assert {
-                "groups": {"aap": {"finance": 1}, "candian": {"domestic_sport": 1}},
-                "subgroups": {"finance": 1, "domestic_sport": 1},
-            } == report
+        params["aggs"] = {
+            "group": {"field": '{"scheme":"packages"}', "size": 0},
+            "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
+        }
+        args["aggs"] = {
+            "group": {"field": '{"scheme":"packages"}', "size": 0},
+            "subgroup": {"field": '{"scheme":"keywords"}', "size": 0},
+        }
+
+        docs = await self.service.run_query(params, args)
+        report = await self.service.generate_report(docs, args)
+        assert {
+            "groups": {"bin": {"aap": 1}, "btl": {"candian": 1}},
+            "subgroups": {"aap": 1, "candian": 1},
+        } == report
+
+        params["aggs"] = {
+            "group": {"field": '{"scheme":"keywords"}', "size": 0},
+            "subgroup": {"field": "anpa_category.qcode", "size": 0},
+        }
+        args["aggs"] = {
+            "group": {"field": '{"scheme":"packages"}', "size": 0},
+            "subgroup": {"field": "anpa_category.qcode", "size": 0},
+        }
+
+        docs = await self.service.run_query(params, args)
+        report = await self.service.generate_report(docs, args)
+        assert {
+            "groups": {"aap": {"finance": 1}, "candian": {"domestic_sport": 1}},
+            "subgroups": {"finance": 1, "domestic_sport": 1},
+        } == report

--- a/server/analytics/desk_activity_report/desk_activity_report.py
+++ b/server/analytics/desk_activity_report/desk_activity_report.py
@@ -120,7 +120,7 @@ class DeskActivityReportService(BaseReportService):
     def get_elastic_index(self, types):
         return "statistics"
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         aggregations = getattr(docs, "hits", {}).get("aggregations") or {}
         desk_filter = (aggregations.get("timeline") or {}).get("desk_filter") or {}
         agg_dates = (desk_filter.get("timeline_filter") or {}).get("dates") or {}
@@ -170,9 +170,9 @@ class DeskActivityReportService(BaseReportService):
 
         return report
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         params = args.get("params") or {}
-        report = self.generate_report(docs, args)
+        report = await self.generate_report(docs, args)
         histogram = params.get("histogram") or {}
 
         def gen_chart_config():

--- a/server/analytics/featuremedia_updates_report/featuremedia_updates_report.py
+++ b/server/analytics/featuremedia_updates_report/featuremedia_updates_report.py
@@ -101,7 +101,7 @@ class FeaturemediaUpdatesTimeReportService(StatsReportService):
 
         return query
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         chart_params = (args.get("params") or {}).get("chart") or {}
         report = {"items": []}
 
@@ -159,8 +159,8 @@ class FeaturemediaUpdatesTimeReportService(StatsReportService):
 
         return report
 
-    def generate_highcharts_config(self, docs, args):
-        report = self.generate_report(docs, args)
+    async def generate_highcharts_config(self, docs, args):
+        report = await self.generate_report(docs, args)
 
         params = args.get("params") or {}
         chart_params = params.get("chart") or {}

--- a/server/analytics/planning_usage_report/planning_usage_report.py
+++ b/server/analytics/planning_usage_report/planning_usage_report.py
@@ -89,7 +89,7 @@ class PlanningUsageReportService(BaseReportService):
     def _get_filters(self, repos, invisible_stages):
         return None
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         """
         Report schema:
         {
@@ -172,13 +172,13 @@ class PlanningUsageReportService(BaseReportService):
 
         return users_with_planning
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         params = args.get("params") or {}
 
         chart = params.get("chart") or {}
         chart_type = chart.get("type") or "bar"
 
-        report = self.generate_report(docs, args)
+        report = await self.generate_report(docs, args)
 
         chart_config = ChartConfig("planning_usage", chart_type)
 

--- a/server/analytics/production_time_report/production_time_report.py
+++ b/server/analytics/production_time_report/production_time_report.py
@@ -74,7 +74,7 @@ class ProductionTimeReportService(StatsReportService):
             }
         }
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         aggregations = getattr(docs, "hits", {}).get("aggregations") or {}
 
         date_filter = (aggregations.get("inner") or {}).get("date_filter") or {}
@@ -103,10 +103,10 @@ class ProductionTimeReportService(StatsReportService):
 
         return report
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         params = args.get("params") or {}
         chart_params = params.get("chart") or {}
-        report = self.generate_report(docs, args)
+        report = await self.generate_report(docs, args)
 
         stats = params.get("stats") or {}
         desk_stats = report.get("desk_stats") or {}

--- a/server/analytics/publishing_performance_report/publishing_performance_report.py
+++ b/server/analytics/publishing_performance_report/publishing_performance_report.py
@@ -77,7 +77,7 @@ class PublishingPerformanceReportService(BaseReportService):
 
         return aggregations
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         """Returns the publishing statistics
 
         :param docs: document used for generating the statistics
@@ -142,7 +142,7 @@ class PublishingPerformanceReportService(BaseReportService):
 
         return report
 
-    def generate_highcharts_config(self, docs, args):
+    async def generate_highcharts_config(self, docs, args):
         params = args.get("params") or {}
         aggs = args.get("aggs") or {}
         group = aggs.get("group") or {}
@@ -152,7 +152,7 @@ class PublishingPerformanceReportService(BaseReportService):
         chart = params.get("chart") or {}
         chart_type = chart.get("type") or "bar"
 
-        report = self.generate_report(docs, args)
+        report = await self.generate_report(docs, args)
 
         chart_config = ChartConfig("content_publishing", chart_type)
 

--- a/server/analytics/stats/archive_statistics.py
+++ b/server/analytics/stats/archive_statistics.py
@@ -12,7 +12,7 @@ from eve.utils import ParsedRequest, date_to_str
 
 from superdesk.resource_fields import ID_FIELD
 from superdesk import get_resource_service, json
-from superdesk.services import BaseService
+from superdesk.eve_async import AsyncBaseService
 from superdesk.resource import Resource, not_indexed, not_analyzed, not_enabled
 from superdesk.metadata.item import (
     metadata_schema,
@@ -249,20 +249,20 @@ class ArchiveStatisticsResource(Resource):
     }
 
 
-class ArchiveStatisticsService(BaseService):
-    def get_last_run(self):
-        return self.find_one(req=None, stats_type="last_run") or {}
+class ArchiveStatisticsService(AsyncBaseService):
+    async def get_last_run(self):
+        return await self.find_one_async(req=None, stats_type="last_run") or {}
 
-    def set_last_run_id(self, entry_id, last_run=None):
+    async def set_last_run_id(self, entry_id, last_run=None):
         if last_run is None:
-            last_run = self.get_last_run()
+            last_run = await self.get_last_run()
 
         if last_run and last_run.get(ID_FIELD):
-            self.patch(last_run[ID_FIELD], {"guid": entry_id})
+            await self.patch_async(last_run[ID_FIELD], {"guid": entry_id})
         else:
-            self.post([{"guid": entry_id, "stats_type": "last_run"}])
+            await self.post_async([{"guid": entry_id, "stats_type": "last_run"}])
 
-    def get_history_items(self, last_id, gte, item_id, chunk_size=0):
+    async def get_history_items(self, last_id, gte, item_id, chunk_size=0):
         history_service = get_resource_service("archive_history")
 
         last_processed_id = last_id
@@ -287,7 +287,7 @@ class ArchiveStatisticsService(BaseService):
             if chunk_size > 0:
                 req.max_results = int(chunk_size)
 
-            items = list(history_service.get(req=req, lookup=None))
+            items = await history_service.get_async(req=req, lookup=None)
 
             if len(items) < 1:
                 break

--- a/server/analytics/stats/featuremedia_updates.py
+++ b/server/analytics/stats/featuremedia_updates.py
@@ -219,6 +219,7 @@ class FeaturemediaUpdates:
         return None if entry is None else ((entry.get("update") or {}).get("associations") or {}).get("featuremedia")
 
     def finish(self, sender):
+        # TODO-ASYNC: update to async calls once this class is migrated to async
         service = get_resource_service("archive_statistics")
 
         query = {"query": {"bool": {"must": {"terms": {"_id": list(self.rewrite_ids)}}}}}

--- a/server/analytics/stats/gen_archive_statistics.py
+++ b/server/analytics/stats/gen_archive_statistics.py
@@ -188,6 +188,7 @@ class GenArchiveStatistics(Command):
         failed_ids = []
         num_history_items = 0
 
+        # TODO-ASYNC: update to async calls once this command is migrated to async
         statistics_service = get_resource_service("archive_statistics")
 
         # Get the system record from the last run
@@ -238,6 +239,7 @@ class GenArchiveStatistics(Command):
     def gen_history_timelines(self, history_items):
         items = {}
 
+        # TODO-ASYNC: update to async calls once this command is migrated to async
         statistics_service = get_resource_service("archive_statistics")
 
         def add_item(entry_id):
@@ -405,6 +407,7 @@ class GenArchiveStatistics(Command):
                 item["updates"][field] = history["update"][field]
 
     def process_timelines(self, items, failed_ids):
+        # TODO-ASYNC: update to async calls once this command is migrated to async
         statistics_service = get_resource_service("archive_statistics")
         items_to_create = []
         rewrites = []

--- a/server/analytics/tests/__init__.py
+++ b/server/analytics/tests/__init__.py
@@ -13,24 +13,12 @@ from typing import Any
 from settings import INSTALLED_APPS
 from superdesk.default_settings import MODULES
 
-from superdesk.tests import TestCase as _TestCase, update_config, setup
-from superdesk.factory.app import get_app
+from superdesk.tests import TestCase
 
 
-class TestCase(_TestCase):
-    def setUp(self):
-        config = {
-            "INSTALLED_APPS": ["analytics"],
-            "STATISTICS_MONGO_DBNAME": "sptests_statistics",
-        }
-        update_config(config)
-        self.app = get_app(config)
-        setup.app = self.app
-        super().setUp()
-
-
-class BaseTestCase(_TestCase):
+class BaseTestCase(TestCase):
     app_config: dict[str, Any] = {
-        "INSTALLED_APPS": INSTALLED_APPS,
+        "INSTALLED_APPS": INSTALLED_APPS + ["analytics"],
         "MODULES": MODULES + ["planning.module"],
+        "STATISTICS_MONGO_DBNAME": "sptests_statistics",
     }

--- a/server/analytics/update_time_report/update_time_report.py
+++ b/server/analytics/update_time_report/update_time_report.py
@@ -72,13 +72,14 @@ class UpdateTimeReportService(StatsReportService):
 
         return query
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         for doc in docs:
             doc.pop("stats", None)
         return docs
 
-    def generate_highcharts_config(self, docs, args):
-        items = list(self.generate_report(docs, args))
+    async def generate_highcharts_config(self, docs, args):
+        cursor = await self.generate_report(docs, args)
+        items = await cursor.to_list()
 
         params = args.get("params") or {}
         chart_params = params.get("chart") or {}

--- a/server/analytics/user_activity_report/__init__.py
+++ b/server/analytics/user_activity_report/__init__.py
@@ -9,7 +9,7 @@
 # at https://www.sourcefabric.org/superdesk/license
 
 import superdesk
-from .user_acitivity_report import UserActivityReportResource, UserActivityReportService
+from .user_activity_report import UserActivityReportResource, UserActivityReportService
 from analytics.common import register_report
 
 

--- a/server/analytics/user_activity_report/user_activity_report.py
+++ b/server/analytics/user_activity_report/user_activity_report.py
@@ -60,10 +60,11 @@ class UserActivityReportService(StatsReportService):
         """Disable generating aggregations"""
         return None
 
-    def generate_report(self, docs, args):
+    async def generate_report(self, docs, args):
         report = {"items": [], "min": 0, "max": 0}
+        print(await docs.to_list())
 
-        for doc in docs:
+        async for doc in docs:
             stats = doc.get("stats") or {}
 
             def calc_timestamp(entry):

--- a/server/analytics/user_activity_report/user_activity_report.py
+++ b/server/analytics/user_activity_report/user_activity_report.py
@@ -62,7 +62,6 @@ class UserActivityReportService(StatsReportService):
 
     async def generate_report(self, docs, args):
         report = {"items": [], "min": 0, "max": 0}
-        print(await docs.to_list())
 
         async for doc in docs:
             stats = doc.get("stats") or {}

--- a/test-server/requirements.txt
+++ b/test-server/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
 honcho==0.6.6
 newrelic>=2.66,<2.67
-git://github.com/superdesk/superdesk-core.git@develop#egg=Superdesk_Core
+git://github.com/superdesk/superdesk-core.git@async#egg=Superdesk_Core


### PR DESCRIPTION
### Purpose
Implements Analytics statistics  service in async 

### What has changed
- Implement async methods in the `archive_statistics` service 
- Adjusted references to new methods
- Fixed reports: `Content Publishing`, `Planning Usage`, `Publishing Performance`

### Pending reports
The next reports are not working fully. At the moment they come back empty because we need to first fix the command `GenArchiveStatistics` that runs every hour with celery beat.

- Desk Activity
- Production Time
- User Activity

Resolves: [SDESK-7591]


[SDESK-7591]: https://sofab.atlassian.net/browse/SDESK-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ