### PR TITLE
[SDESK-7315] Upgrade Analytics commands to use click library

### DIFF
--- a/server/analytics/commands/send_schedule_reports_test.py
+++ b/server/analytics/commands/send_schedule_reports_test.py
@@ -10,19 +10,19 @@
 
 import pytz
 
+from os import urandom
+from unittest import mock
 from datetime import datetime
 from dateutil.rrule import rrule, HOURLY
-from unittest import mock
-from os import urandom
 from base64 import b64encode, b64decode
 
 from superdesk.core import get_app_config
 from superdesk import get_resource_service
 from superdesk.utc import local_to_utc
 
-from analytics.tests import BaseTestCase, markers
-from analytics.commands.send_scheduled_reports import SendScheduledReports
 from analytics.common import MIME_TYPES
+from analytics.tests import BaseTestCase
+from analytics.commands.send_scheduled_reports import SendScheduledReports
 from analytics.email_report.email_report import EmailReportService
 
 
@@ -101,7 +101,7 @@ class SendScheduleReportTestCase(BaseTestCase):
             local_tz = pytz.timezone(default_timezone)
             now_local = local_tz.localize(now)
 
-            response = self.should_send(report, now_local)
+            response = await self.should_send(report, now_local)
 
             self.assertEqual(
                 response,
@@ -117,7 +117,6 @@ class SendScheduleReportTestCase(BaseTestCase):
         self.assertEqual(len(expected_hits), count)
 
     @mock.patch("analytics.email_report.email_report.generate_report", return_value=mock_file)
-    @markers.requires_async_commands
     async def test_run_hourly_png(self, mocked):
         self.app.data.insert("users", mock_users)
         self.app.data.insert("vocabularies", mock_vocabs)
@@ -148,13 +147,13 @@ class SendScheduleReportTestCase(BaseTestCase):
         start_date = to_naive("2018-06-30T00")
         end_date = to_naive("2018-06-30T03")
         default_timezone = get_app_config("DEFAULT_TIMEZONE")
-        local_tz = default_timezone
+        local_tz = pytz.timezone(default_timezone)
         with self.app.mail.record_messages() as outbox:
             for now in rrule(HOURLY, dtstart=start_date, until=end_date):
                 now_local = local_tz.localize(now)
                 now_utc = local_to_utc(default_timezone, now_local)
 
-                SendScheduledReports().run(now_utc)
+                await SendScheduledReports().run(now_utc)
 
                 # _last sent is updated
                 report = await scheduled_service.find_one_async(req=None, _id="sched1")
@@ -185,7 +184,6 @@ class SendScheduleReportTestCase(BaseTestCase):
         self.assertEqual(report.get("_last_sent"), to_utc("2018-06-30T03"))
 
     @mock.patch("analytics.email_report.email_report.generate_report", return_value=mock_file)
-    @markers.requires_async_commands
     async def test_run_daily_jpeg(self, mocked):
         self.app.data.insert("users", mock_users)
         self.app.data.insert("vocabularies", mock_vocabs)
@@ -217,13 +215,13 @@ class SendScheduleReportTestCase(BaseTestCase):
         end_date = to_naive("2018-06-30T03")
         should_have_updated = False
         default_timezone = get_app_config("DEFAULT_TIMEZONE")
+        local_tz = pytz.timezone(default_timezone)
         with self.app.mail.record_messages() as outbox:
             for now in rrule(HOURLY, dtstart=start_date, until=end_date):
-                local_tz = pytz.timezone(default_timezone)
                 now_local = local_tz.localize(now)
                 now_utc = local_to_utc(default_timezone, now_local)
 
-                SendScheduledReports().run(now_utc)
+                await SendScheduledReports().run(now_utc)
 
                 # _last sent is updated
                 report = await scheduled_service.find_one_async(req=None, _id="sched1")
@@ -249,7 +247,6 @@ class SendScheduleReportTestCase(BaseTestCase):
         self.assertEqual(report.get("_last_sent"), to_utc("2018-06-30T01"))
 
     @mock.patch("analytics.email_report.email_report.generate_report", return_value=mock_csv)
-    @markers.requires_async_commands
     async def test_email_csv(self, mocked):
         self.app.data.insert("users", mock_users)
         self.app.data.insert("vocabularies", mock_vocabs)
@@ -272,7 +269,7 @@ class SendScheduleReportTestCase(BaseTestCase):
         )
 
         with self.app.mail.record_messages() as outbox:
-            SendScheduledReports().run("2018-06-30T00")
+            await SendScheduledReports().run("2018-06-30T00")
 
             self.assertEqual(len(outbox), 1)
 
@@ -286,7 +283,6 @@ class SendScheduleReportTestCase(BaseTestCase):
             self.assertEqual(outbox[0].attachments[0].data, b64decode(mock_csv))
 
     @mock.patch.object(EmailReportService, "_gen_attachments", return_value=mock_array)
-    @markers.requires_async_commands
     async def test_email_multiple_attachments(self, mock):
         self.app.data.insert("users", mock_users)
         self.app.data.insert("vocabularies", mock_vocabs)
@@ -327,7 +323,7 @@ class SendScheduleReportTestCase(BaseTestCase):
         )
 
         with self.app.mail.record_messages() as outbox:
-            SendScheduledReports().run("2018-06-30T00")
+            await SendScheduledReports().run("2018-06-30T00")
 
             self.assertEqual(len(outbox), 1)
 

--- a/server/analytics/commands/send_scheduled_reports.py
+++ b/server/analytics/commands/send_scheduled_reports.py
@@ -8,38 +8,40 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import click
 from datetime import datetime
 
-from superdesk.core import get_app_config
-from superdesk import Command, command, Option, get_resource_service
+from superdesk.commands import cli
 from superdesk.logging import logger
+from superdesk.core import get_app_config
+from superdesk import get_resource_service
 from superdesk.errors import SuperdeskApiError
 from superdesk.utc import utc_to_local, utcnow, local_to_utc
 
 
-class SendScheduledReports(Command):
+@cli.command("analytics:send_scheduled_reports")
+@click.option(
+    "--now", "-n", is_flag=True, required=False, help="Local date/hour in the format '%Y-%m-%dT%H', i.e. 2018-09-13T10"
+)
+async def send_scheduled_reports(now):
     """
     Send scheduled reports
 
     Example:
-    ::
 
         $ python manage.py analytics:send_scheduled_reports
         $ python manage.py analytics:send_scheduled_reports --now
 
     """
+    await SendScheduledReports().run(now)
 
-    option_list = [
-        Option(
-            "--now",
-            "-n",
-            dest="now",
-            required=False,
-            help="Local date/hour in the format '%Y-%m-%dT%H', i.e. 2018-09-13T10",
-        )
-    ]
 
-    def run(self, now=None):
+class SendScheduledReports:
+    """
+    Send scheduled reports command class handler
+    """
+
+    async def run(self, now=None):
         default_timezone = get_app_config("DEFAULT_TIMEZONE")
         if now:
             now_utc = (
@@ -54,7 +56,7 @@ class SendScheduledReports(Command):
 
         logger.info("Starting to send scheduled reports: {}".format(now_utc))
 
-        schedules = self.get_schedules()
+        schedules = await self.get_schedules()
 
         if len(schedules) < 1:
             logger.info("No enabled schedules found, not continuing")
@@ -67,16 +69,15 @@ class SendScheduledReports(Command):
             schedule_id = str(scheduled_report.get("_id"))
 
             try:
-                if not self.should_send_report(scheduled_report, now_local):
+                if not await self.should_send_report(scheduled_report, now_local):
                     logger.info("Scheduled Report {} not scheduled to be sent".format(schedule_id))
                     continue
 
                 logger.info("Attempting to send Scheduled Report {}".format(schedule_id))
-                self._send_report(scheduled_report)
+                await self._send_report(scheduled_report)
 
                 # Update the _last_sent of the schedule
-                # TODO-ASYNC: update all usages of `scheduled_reports` once the command is migrated to async
-                get_resource_service("scheduled_reports").system_update(
+                await get_resource_service("scheduled_reports").system_update_async(
                     scheduled_report.get("_id"),
                     {"_last_sent": now_utc},
                     scheduled_report,
@@ -88,11 +89,12 @@ class SendScheduledReports(Command):
         logger.info("Completed sending scheduled reports: {}".format(now_utc))
 
     @staticmethod
-    def get_schedules():
-        return list(get_resource_service("scheduled_reports").get(req=None, lookup={"active": {"$eq": True}}))
+    async def get_schedules():
+        cursor = await get_resource_service("scheduled_reports").get_async(req=None, lookup={"active": {"$eq": True}})
+        return await cursor.to_list()
 
     @staticmethod
-    def should_send_report(scheduled_report, now_local):
+    async def should_send_report(scheduled_report, now_local):
         # Set now to the beginning of the hour (in local time)
         now_to_hour = now_local.replace(minute=0, second=0, microsecond=0)
 
@@ -132,10 +134,9 @@ class SendScheduledReports(Command):
         return True
 
     @staticmethod
-    def _send_report(scheduled_report):
+    async def _send_report(scheduled_report):
         email_service = get_resource_service("email_report")
-        # TODO-ASYNC: update usage of `saved_reports` to async once the command is async
-        saved_report = get_resource_service("saved_reports").find_one(
+        saved_report = await get_resource_service("saved_reports").find_one_async(
             req=None, _id=scheduled_report.get("saved_report")
         )
 
@@ -145,7 +146,7 @@ class SendScheduledReports(Command):
         extra = scheduled_report.get("extra") or {}
         body = extra.get("body") or "Superdesk Analytics - {}".format(scheduled_report.get("name"))
 
-        email_service.post(
+        await email_service.post_async(
             [
                 {
                     "report": {
@@ -163,6 +164,3 @@ class SendScheduledReports(Command):
                 }
             ]
         )
-
-
-command("analytics:send_scheduled_reports", SendScheduledReports())

--- a/server/analytics/email_report/email_report.py
+++ b/server/analytics/email_report/email_report.py
@@ -98,7 +98,7 @@ class EmailReportResource(Resource):
 class EmailReportService(AsyncBaseService):
     async def create_async(self, docs, **kwargs):
         for doc in docs:
-            attachments = self._gen_attachments(doc.get("report") or {})
+            attachments = await self._gen_attachments(doc.get("report") or {})
             await self._email_report(doc.get("email") or {}, attachments)
 
         # We're not actually saving anything to the database
@@ -106,9 +106,10 @@ class EmailReportService(AsyncBaseService):
         return [0]
 
     @staticmethod
-    def _gen_attachments(report):
+    async def _gen_attachments(report):
         # TODO-ASYNC: make this async once all report services are made async
         report_service = get_report_service(report.get("type"))
+
         if report_service is None:
             raise SuperdeskApiError.badRequestError('Unknown report type "{}"'.format(report.get("type")))
 
@@ -127,7 +128,7 @@ class EmailReportService(AsyncBaseService):
             return_type = "aggregations"
 
         generated_report = list(
-            report_service.get(
+            await report_service.get_async(
                 req=None,
                 params=report.get("params") or {},
                 translations=report.get("translations") or {},

--- a/server/analytics/reports/generate_report_test.py
+++ b/server/analytics/reports/generate_report_test.py
@@ -8,7 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
-from analytics.tests import BaseTestCase, markers
+from analytics.tests import BaseTestCase
 from analytics.reports import generate_report
 from analytics.common import MIME_TYPES
 
@@ -23,7 +23,6 @@ options = {
 }
 
 
-@markers.fix_highchart_server
 class GenerateReportTestCase(BaseTestCase):
     async def test_generate_svg(self):
         report = generate_report(options, mimetype=MIME_TYPES.SVG, base64=False)

--- a/server/analytics/stats/archive_statistics.py
+++ b/server/analytics/stats/archive_statistics.py
@@ -267,30 +267,28 @@ class ArchiveStatisticsService(AsyncBaseService):
 
         last_processed_id = last_id
 
+        def build_query():
+            conditions = []
+            if gte:
+                conditions.append({"_created": {"$gte": date_to_str(gte)}})
+            if item_id:
+                conditions.append({"item_id": str(item_id)})
+            if last_processed_id:
+                conditions.append({"_id": {"$gt": str(last_processed_id)}})
+            return {"$and": conditions}
+
         while True:
             req = ParsedRequest()
             req.sort = '[("_id", 1), ("version", 1)]'
-
-            query = {"$and": []}
-
-            if gte:
-                query["$and"].append({"_created": {"$gte": date_to_str(gte)}})
-
-            if item_id:
-                query["$and"].append({"item_id": str(item_id)})
-
-            if last_processed_id:
-                query["$and"].append({"_id": {"$gt": str(last_processed_id)}})
-
-            req.where = json.dumps(query)
+            req.where = json.dumps(build_query())
 
             if chunk_size > 0:
                 req.max_results = int(chunk_size)
 
             items = await history_service.get_async(req=req, lookup=None)
-
-            if len(items) < 1:
+            if not await items.count():
                 break
 
+            items = await items.to_list()
             last_processed_id = items[-1][ID_FIELD]
             yield items

--- a/server/analytics/stats/gen_archive_statistics.py
+++ b/server/analytics/stats/gen_archive_statistics.py
@@ -8,13 +8,16 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+import click
+
 from copy import deepcopy
 from datetime import timedelta
 
-from superdesk.resource_fields import ID_FIELD
-from superdesk import Command, command, get_resource_service, Option
-from superdesk.logging import logger
 from superdesk.utc import utcnow
+from superdesk.commands import cli
+from superdesk.logging import logger
+from superdesk import get_resource_service
+from superdesk.resource_fields import ID_FIELD
 from superdesk.metadata.item import (
     ITEM_STATE,
     ITEM_TYPE,
@@ -32,6 +35,7 @@ from superdesk.signals import signals
 
 from analytics.stats.common import STAT_TYPE, OPERATION
 from analytics.stats import desk_transitions
+
 
 gen_stats_signals = {
     "start": signals.signal("gen_archive_statistics:start"),
@@ -79,14 +83,17 @@ def connect_stats_signals(
         gen_stats_signals["finish"].connect(on_finish)
 
 
-class GenArchiveStatistics(Command):
+@cli.command("analytics:gen_archive_statistics")
+@click.option("--max-days", "-d", required=False, default=3)
+@click.option("--item-id", "-i", required=False)
+@click.option("--chunk-size", "-c", required=False, default=1000)
+async def gen_archive_statistics(max_days: int, item_id: str, chunk_size: int):
     """Generate statistics for archive documents based on archive_history documents
 
     Generates a linear timeline of operations based on documents from archive_history.
     This data is then used to search and aggregate for usage in generating charts.
 
-    Options
-    ::
+    Options:
 
         -d, --max-days (defaults to 3):
         Maximum number of days to process from archive_history
@@ -99,7 +106,6 @@ class GenArchiveStatistics(Command):
     celery on a schedule every hour (minute=0).
 
     Example:
-    ::
 
         $ python manage.py analytics:gen_archive_statistics
         $ python manage.py analytics:gen_archive_statistics -d 1
@@ -114,7 +120,6 @@ class GenArchiveStatistics(Command):
     There is a dictionary in the schema for custom stats to be stored under the 'extra' attribute.
 
     Example:
-    ::
 
         from analytics.stats.gen_archive_statistics import connect_stats_signals
 
@@ -124,13 +129,15 @@ class GenArchiveStatistics(Command):
 
     """
 
-    option_list = [
-        Option("--max-days", "-d", dest="max_days", default=3),
-        Option("--item-id", "-i", dest="item_id", default=None),
-        Option("--chunk-size", "-c", dest="chunk_size", default=1000),
-    ]
+    await GenArchiveStatistics().run(max_days, item_id, chunk_size)
 
-    def run(self, max_days=3, item_id=None, chunk_size=1000):
+
+class GenArchiveStatistics:
+    """
+    Generate archive statistics command handler class.
+    """
+
+    async def run(self, max_days=3, item_id=None, chunk_size=1000):
         now_utc = utcnow()
 
         # If we're generating stats for a single item, then
@@ -167,7 +174,7 @@ class GenArchiveStatistics(Command):
         num_history_items = 0
 
         try:
-            items_processed, failed_ids, num_history_items = self.generate_stats(item_id, gte, chunk_size)
+            items_processed, failed_ids, num_history_items = await self.generate_stats(item_id, gte, chunk_size)
         except Exception:
             logger.exception("Failed to generate archive stats")
         finally:
@@ -183,24 +190,23 @@ class GenArchiveStatistics(Command):
             )
         )
 
-    def generate_stats(self, item_id, gte, chunk_size):
+    async def generate_stats(self, item_id, gte, chunk_size):
         items_processed = 0
         failed_ids = []
         num_history_items = 0
-
-        # TODO-ASYNC: update to async calls once this command is migrated to async
         statistics_service = get_resource_service("archive_statistics")
 
         # Get the system record from the last run
         # This document stores the id of the last processed archive_history item
-        last_history = statistics_service.get_last_run()
+        last_history = await statistics_service.get_last_run()
         last_entry_id = last_history.get("guid") or None
 
         if last_history.get("guid"):
             logger.info("Found previous run, continuing from history item {}".format(last_history["guid"]))
 
         iterated_started = utcnow()
-        for history_items in statistics_service.get_history_items(last_entry_id, gte, item_id, chunk_size):
+
+        async for history_items in statistics_service.get_history_items(last_entry_id, gte, item_id, chunk_size):
             if len(history_items) < 1:
                 logger.info("No more history records to process")
                 break
@@ -210,9 +216,9 @@ class GenArchiveStatistics(Command):
             num_history_items += len(history_items)
             last_entry_id = history_items[-1].get(ID_FIELD)
 
-            items = self.gen_history_timelines(history_items)
+            items = await self.gen_history_timelines(history_items)
             items_processed += len(items)
-            self.process_timelines(items, failed_ids)
+            await self.process_timelines(items, failed_ids)
 
             time_diff = (utcnow() - iterated_started).total_seconds()
             logger.info(
@@ -232,21 +238,19 @@ class GenArchiveStatistics(Command):
         if not item_id:
             # Create/Update the system record from this run
             # Storing the id of the last processed archive_history item
-            statistics_service.set_last_run_id(last_entry_id, last_history)
+            await statistics_service.set_last_run_id(last_entry_id, last_history)
 
         return items_processed, failed_ids, num_history_items
 
-    def gen_history_timelines(self, history_items):
+    async def gen_history_timelines(self, history_items):
         items = {}
-
-        # TODO-ASYNC: update to async calls once this command is migrated to async
         statistics_service = get_resource_service("archive_statistics")
 
-        def add_item(entry_id):
+        async def add_item(entry_id):
             if items.get(entry_id):
                 return
 
-            item = statistics_service.find_one(req=None, _id=str(entry_id)) or {}
+            item = await statistics_service.find_one_async(req=None, _id=str(entry_id)) or {}
 
             if not item.get("stats"):
                 item["stats"] = {}
@@ -274,7 +278,7 @@ class GenArchiveStatistics(Command):
                 history_item["update"] = {}
 
             try:
-                add_item(item_id)
+                await add_item(item_id)
                 self.gen_archive_stats_from_history(items[item_id], history_item)
             except Exception:
                 logger.exception(
@@ -406,8 +410,7 @@ class GenArchiveStatistics(Command):
             if field in history["update"]:
                 item["updates"][field] = history["update"][field]
 
-    def process_timelines(self, items, failed_ids):
-        # TODO-ASYNC: update to async calls once this command is migrated to async
+    async def process_timelines(self, items, failed_ids):
         statistics_service = get_resource_service("archive_statistics")
         items_to_create = []
         rewrites = []
@@ -429,7 +432,7 @@ class GenArchiveStatistics(Command):
                 items_to_create.append(item["updates"])
             else:
                 try:
-                    statistics_service.patch(item_id, item["updates"])
+                    await statistics_service.patch_async(item_id, item["updates"])
                 except Exception:
                     logger.exception(
                         "Failed to update stats for item {}. updates={}".format(item_id, item.get("updates"))
@@ -438,7 +441,7 @@ class GenArchiveStatistics(Command):
 
         if len(items_to_create) > 0:
             try:
-                statistics_service.post(items_to_create)
+                await statistics_service.post_async(items_to_create)
             except Exception:
                 item_ids = [item.get(ID_FIELD) for item in items_to_create]
                 logger.exception("Failed to create stat entries for items {}".format(", ".join(item_ids)))
@@ -457,7 +460,7 @@ class GenArchiveStatistics(Command):
                 logger.warning("Failed {}, original_id not defined".format(item_id))
                 continue
 
-            original = statistics_service.find_one(req=None, _id=original_id)
+            original = await statistics_service.find_one_async(req=None, _id=original_id)
             if not original:
                 logger.warning("Failed {}, original not found".format(item_id))
                 continue
@@ -467,7 +470,7 @@ class GenArchiveStatistics(Command):
                 logger.warning("Failed {}, published_at not defined".format(original_id))
                 continue
 
-            statistics_service.patch(
+            await statistics_service.patch_async(
                 original_id,
                 {"time_to_next_update_publish": (updated_at - published_at).total_seconds()},
             )
@@ -627,6 +630,3 @@ class GenArchiveStatistics(Command):
 
         if "original_par_count" not in updates and entry["par_count"] > 0:
             updates["original_par_count"] = entry["par_count"]
-
-
-command("analytics:gen_archive_statistics", GenArchiveStatistics())

--- a/server/analytics/tests/markers.py
+++ b/server/analytics/tests/markers.py
@@ -1,8 +1,0 @@
-from pytest import mark
-
-# Skips the test, due to commands not being async
-requires_async_commands = mark.skip(reason="Requires commands to be async")
-
-# highcharts server generation is not working on Github Actions
-# need to figure out why and then enable the tests
-fix_highchart_server = mark.skip(reason="Highcharts server fails")


### PR DESCRIPTION
### Purpose 
Migrate the analytics command to async. 

### What has changed
- Upgraded commands to use `click` library and our new `superdesk-core` commands implementation
- Adjusted services async methods and corresponding references to be async too
- Fixed all pytests (now 100% green without skipped tests)
- Removed not necessary markers module (no longer used/needed) 

Resolves: [SDESK-7315]

[SDESK-7315]: https://sofab.atlassian.net/browse/SDESK-7315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ