### PR TITLE
Fix `gen_archive_stats` to run async command

### DIFF
--- a/server/analytics/stats/__init__.py
+++ b/server/analytics/stats/__init__.py
@@ -63,5 +63,5 @@ def init_gen_stats_task(app):
 
 
 @celery.task(soft_time_limit=600)
-def gen_archive_stats():
-    GenArchiveStatistics().run()
+async def gen_archive_stats():
+    await GenArchiveStatistics().run()


### PR DESCRIPTION
The generation of stats was not working due to a missing async call (the command was not properly awaited).

Thanks for checking!