### PR TITLE
Adjust statistics MongoDB URI to fallback to main `MONGO_URI`

### DIFF
--- a/server/analytics/stats/__init__.py
+++ b/server/analytics/stats/__init__.py
@@ -18,6 +18,14 @@ from .gen_archive_statistics import GenArchiveStatistics
 from .featuremedia_updates import *  # noqa
 
 
+def get_default_mongo_uri(app, db_name: str) -> str:
+    """
+    Get the default MongoDB URI for the given database name.
+    """
+    base_uri = app.config["MONGO_URI"]
+    return base_uri.rsplit("/", 1)[0] + "/" + db_name
+
+
 def init_app(app):
     if not app.config.get("STATISTICS_MONGO_DBNAME"):
         app.config["STATISTICS_MONGO_DBNAME"] = env("STATISTICS_MONGO_DBNAME", "statistics")
@@ -25,7 +33,10 @@ def init_app(app):
     db_name = app.config["STATISTICS_MONGO_DBNAME"]
 
     if not app.config.get("STATISTICS_MONGO_URI"):
-        app.config["STATISTICS_MONGO_URI"] = env("STATISTICS_MONGO_URI", "mongodb://localhost/%s" % db_name)
+        app.config["STATISTICS_MONGO_URI"] = env(
+            "STATISTICS_MONGO_URI",
+            get_default_mongo_uri(app, db_name),
+        )
 
     if not app.config.get("STATISTICS_ELASTIC_URL"):
         app.config["STATISTICS_ELASTIC_URL"] = env("STATISTICS_ELASTIC_URL", app.config["ELASTICSEARCH_URL"])


### PR DESCRIPTION
When `STATISTICS_MONGO_URI` is not set in environment, use the main `MONGO_URI` but with statistics database name. This ensures we use the same MongoDB connection settings (host, auth, etc.) as the main database while keeping the statistics in a separate database.
