### PR TITLE
[SDESK-7591] Fix `send_scheduled_reports` missing async call

### DIFF
--- a/server/analytics/__init__.py
+++ b/server/analytics/__init__.py
@@ -177,5 +177,5 @@ def init_app(app):
 
 
 @celery.task(soft_time_limit=600)
-def send_scheduled_reports():
-    SendScheduledReports().run()
+async def send_scheduled_reports():
+    await SendScheduledReports().run()


### PR DESCRIPTION
This fix a problem with the scheduled sending of the reports reported by QA team. 

Resolves: [SDESK-7591]



[SDESK-7591]: https://sofab.atlassian.net/browse/SDESK-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ