### PR TITLE
[SDESK-7852] Strip deprecated ~ prefix from SCSS imports

### DIFF
--- a/client/charts/styles/charts.scss
+++ b/client/charts/styles/charts.scss
@@ -1,9 +1,9 @@
 $colors: #7cb5ec #434348 #90ed7d #f7a35c #8085e9 #f15c80 #e4d354 #2b908f #f45b5b #91e8e1;
 
-@import '~highcharts/css/highcharts.scss';
-@import '~superdesk-ui-framework/app/styles/_reboot.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_typography.scss';
-@import '~superdesk-ui-framework/app/styles/variables/_colors.scss';
+@import 'highcharts/css/highcharts.scss';
+@import 'superdesk-ui-framework/app/styles/_reboot.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_typography.scss';
+@import 'superdesk-ui-framework/app/styles/variables/_colors.scss';
 
 .sda-chart__container {
     width: 100%;

--- a/client/styles/analytics.scss
+++ b/client/styles/analytics.scss
@@ -1,9 +1,9 @@
 // analytics.scss
 // Styling for analytics page, and analytics functionalities
 // ----------------------------------------------------------------------------------------
-@import '~mixins.scss';
-@import '~variables.scss';
-@import '~animation.scss';
+@import 'mixins.scss';
+@import 'variables.scss';
+@import 'animation.scss';
 
 .report-page-container {
     .report-content {


### PR DESCRIPTION
### Purpose
The `~` prefix on `@import` paths is deprecated in `sass-loader` 10 and removed in `sass-loader` 16. Stripping it now keeps analytics building when client-core eventually moves to `sass-loader` 16. The compiled CSS is unchanged: webpack still resolves bare specifiers (`mixins.scss`, `highcharts/css/highcharts.scss`, `superdesk-ui-framework/app/styles/variables/_colors.scss`, etc.) via `resolve.modules` and aliases.

Companion PRs already merged:
- planning https://github.com/superdesk/superdesk-planning/pull/2868 
- client-core https://github.com/superdesk/superdesk-client-core/pull/5234. 

### What has changed
Removed the leading `~` from 7 `@import` statements across 2 SCSS files. Nothing else.

### Steps to test
- Analytics' own CI build (still on `sass-loader` 10) should be green. That confirms bare specifiers still resolve.
- Integrated superdesk dev build (`npm run start` from `superdesk/client`): charts and analytics views render as before.

[SDESK-7852]


[SDESK-7852]: https://sofab.atlassian.net/browse/SDESK-7852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ